### PR TITLE
feat added: simple desktop navbar

### DIFF
--- a/components/navigation/navbar.css
+++ b/components/navigation/navbar.css
@@ -1,0 +1,55 @@
+/* Styling for navbar */
+.nav {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  padding: var(--scale-sm);
+  width: 100%;
+}
+.nav a {
+  color: var(--default-text-color);
+  text-decoration: none;
+}
+.nav__links {
+  margin-right: var(--scale-lg);
+}
+.nav__logo {
+  margin-left: var(--scale-lg);
+}
+
+.nav__links a:hover {
+  color: var(--active-color);
+}
+.nav ul {
+  align-self: flex-end;
+  display: flex;
+  justify-content: space-evenly;
+  margin-left: auto;
+}
+.nav ul li {
+  margin: 0 var(--scale-sm);
+}
+
+/* Styling For Dark Navbar */
+.nav__bg-dark {
+  background-color: var(--dark-color);
+}
+.nav__bg-dark a,
+* {
+  color: var(--off-white);
+}
+
+/* Adding Breakpoints */
+@media only screen and (max-width: 480px) {
+  .nav {
+    align-items: center;
+    justify-content: center;
+  }
+  .nav__links,
+  .nav__logo {
+    margin: 0;
+  }
+  .nav ul {
+    margin: 0;
+  }
+}

--- a/stylesheets/utils/utility.css
+++ b/stylesheets/utils/utility.css
@@ -21,7 +21,6 @@ Utility Classes
   color: var(--dark-color);
 }
 
-
 .transition {
   transition: 1s, color 0.15s ease-in-out, background-color 0.15s ease-in-out,
     border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
@@ -68,7 +67,9 @@ img {
   max-width: 100%;
   height: auto;
 }
-.shadow-lg{
+.shadow-lg {
   box-shadow: #00000059 0px 5px 15px;
 }
-
+.hide {
+  display: none;
+}


### PR DESCRIPTION
Added stylesheet for simple desktop navbar.
<img width="1440" alt="Screenshot 2022-02-05 at 10 54 06 PM" src="https://user-images.githubusercontent.com/67017632/152652033-814a4e12-e698-4d61-b041-431743defc12.png">
<img width="654" alt="Screenshot 2022-02-05 at 10 54 44 PM" src="https://user-images.githubusercontent.com/67017632/152652053-2b7e3d09-420a-45b2-80e8-dc872b9ee91a.png">

